### PR TITLE
Allow get_session_key to use FormParser

### DIFF
--- a/netbox_secrets/api/views.py
+++ b/netbox_secrets/api/views.py
@@ -151,6 +151,9 @@ class GetSessionKeyViewSet(ViewSet):
 
     permission_classes = [IsAuthenticated]
 
+    # Override Netbox DEFAULT_PARSER_CLASSES - FormParser is required to process url encoded private_key
+    parser_classes = [JSONParser, FormParser]
+    
     @swagger_auto_schema(
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,


### PR DESCRIPTION
FormParser is required to handle the URL encoded private_key for retrieving session keys from the API.

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue
#47
<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior
Allow FormParser when dealing with session key via API.
<!--
Please describe in a few words the intentions of your PR.
-->

---

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->
Default netbox behavior disables FormParser
---

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->
Required to use the API to retrieve session keys
---

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->
This makes the documentation correct as written, currently fails as documented.
---

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x ] I have explained my PR according to the information in the comments
 or in a linked issue.
* [ x] My PR targets the `dev` branch.
