### PR TITLE
Fix migration to skip deleted devices and virtual machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased](https://github.com/Onemind-Services-LLC/netbox-secrets/tree/HEAD)
+
+[Full Changelog](https://github.com/Onemind-Services-LLC/netbox-secrets/compare/v1.8.3...HEAD)
+
+**Closed issues:**
+
+- \[Bug\]: Migration Failure due to previous bug [\#73](https://github.com/Onemind-Services-LLC/netbox-secrets/issues/73)
+
+**Merged pull requests:**
+
+- Prepare for release [\#74](https://github.com/Onemind-Services-LLC/netbox-secrets/pull/74) ([kprince28](https://github.com/kprince28))
+- Fix copy of data in migration [\#72](https://github.com/Onemind-Services-LLC/netbox-secrets/pull/72) ([kprince28](https://github.com/kprince28))
+
 ## [v1.8.3](https://github.com/Onemind-Services-LLC/netbox-secrets/tree/v1.8.3) (2023-06-02)
 
 [Full Changelog](https://github.com/Onemind-Services-LLC/netbox-secrets/compare/v1.8.2...v1.8.3)

--- a/netbox_secrets/migrations/0007_secret__object_repr_secret_comments_and_more.py
+++ b/netbox_secrets/migrations/0007_secret__object_repr_secret_comments_and_more.py
@@ -6,15 +6,16 @@ from django.db import migrations, models
 
 def copy_assigned_object(apps, schema_editor):
     Secret = apps.get_model('netbox_secrets', 'Secret')
-    try:
-        for secret in Secret.objects.all():
-            content_type = ContentType.objects.get(id=secret.assigned_object_type_id)
-            Model = apps.get_model(content_type.app_label, str(content_type.model).capitalize())
-            object = Model.objects.filter(id=secret.assigned_object_id).first()
-            secret._object_repr = object.name
-            secret.save()
-    except:
-        pass
+    for secret in Secret.objects.all():
+        content_type = ContentType.objects.get(id=secret.assigned_object_type_id)
+        Model = apps.get_model(content_type.app_label, str(content_type.model).capitalize())
+        object = Model.objects.filter(id=secret.assigned_object_id).first()
+        if not object:
+            continue
+        secret._object_repr = object.name
+        secret.save()
+
+
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
# Pull Request

## Description

- This pull request addresses an issue with the migration process for secrets in the `copy_assigned_object` function. It ensures that the migration skips secrets associated with deleted devices and virtual machines, preventing errors during the migration process.