### PR TITLE
Fix schema generation error in LegacyActivateUserKeyViewSet

### DIFF
--- a/netbox_secrets/api/views.py
+++ b/netbox_secrets/api/views.py
@@ -714,7 +714,7 @@ class LegacySessionKeyViewSet(
         return response
 
 
-class LegacyActivateUserKeyViewSet(ViewSet):
+class LegacyActivateUserKeyViewSet(GenericViewSet):
     """
     Backward-compatible endpoint for /activate-user-key/.
 


### PR DESCRIPTION
## Summary

- `LegacyActivateUserKeyViewSet` extends `ViewSet` and defines `serializer_class`, but `ViewSet` does not provide `get_serializer()`. During OpenAPI schema generation (`/api/schema/`), drf-spectacular returns the serializer **class** instead of an **instance**, causing `serializer.fields` to return the raw `cached_property` descriptor instead of the actual fields dict.
- Changed the base class from `ViewSet` to `GenericViewSet` (already imported in the module), which provides `get_serializer()` and resolves the error.

## Error

```
File "/opt/netbox/netbox/core/api/schema.py", line 233, in get_writable_class
    for child_name, child in fields.items():
                             ^^^^^^^^^^^^
AttributeError: 'cached_property' object has no attribute 'items'
```

This causes a 500 Internal Server Error on `/api/schema/` and `/api/schema/swagger-ui/`.

## Test plan

- [ ] Verify `/api/schema/` returns 200 instead of 500
- [ ] Verify `/api/plugins/secrets/activate-user-key/` endpoint still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)