### PR TITLE
fix(SessionKey): wrap bytes through base64 for Django 5.x make_password (NetBox 4.6+)

### DIFF
--- a/netbox_secrets/models/keys.py
+++ b/netbox_secrets/models/keys.py
@@ -6,6 +6,7 @@ This module contains models for managing encryption keys:
 - SessionKey: Manages temporary session keys for secret encryption/decryption
 """
 
+import base64
 from typing import Optional
 
 from Crypto.PublicKey import RSA
@@ -23,6 +24,20 @@ from utilities.querysets import RestrictedQuerySet
 from ..constants import CENSOR_MASTER_KEY, CENSOR_MASTER_KEY_CHANGED
 from ..exceptions import InvalidKey
 from ..querysets import UserKeyQuerySet
+
+
+def _bytes_to_password_str(value: bytes) -> str:
+    """
+    Encode arbitrary bytes as an ASCII string suitable for Django password
+    hashers.
+
+    Django 5.x's :func:`django.contrib.auth.hashers.make_password` (and
+    :func:`check_password`) only accept ``str``. NetBox Secrets uses random
+    32-byte session keys, which are not necessarily valid UTF-8. Base64
+    encoding is bijective on bytes, so any subsequent verification round-trip
+    is identical.
+    """
+    return base64.b64encode(value).decode('ascii')
 from ..utils import decrypt_master_key, encrypt_master_key, generate_random_key
 
 __all__ = [
@@ -327,8 +342,9 @@ class SessionKey(models.Model):
         if self.key is None:
             self.key = generate_random_key()
 
-        # Hash session key for validation
-        self.hash = make_password(self.key)
+        # Hash session key for validation (base64-wrap raw bytes for Django 5.x
+        # make_password, which only accepts str).
+        self.hash = make_password(_bytes_to_password_str(self.key))
 
         # Encrypt master key with session key using XOR
         self.cipher = strxor.strxor(self.key, master_key)
@@ -348,7 +364,7 @@ class SessionKey(models.Model):
         Raises:
             InvalidKey: If session key is invalid
         """
-        if not check_password(session_key, self.hash):
+        if not check_password(_bytes_to_password_str(session_key), self.hash):
             raise InvalidKey(_("Invalid session key"))
 
         return strxor.strxor(session_key, bytes(self.cipher))
@@ -371,7 +387,7 @@ class SessionKey(models.Model):
         """
         session_key = strxor.strxor(master_key, bytes(self.cipher))
 
-        if not check_password(session_key, self.hash):
+        if not check_password(_bytes_to_password_str(session_key), self.hash):
             raise InvalidKey(_("Invalid master key"))
 
         return session_key


### PR DESCRIPTION
## Summary

`SessionKey.save()`, `SessionKey.get_master_key()`, and `SessionKey.get_session_key()` pass raw `bytes` to `django.contrib.auth.hashers.make_password()` / `check_password()`. In Django 5.x (NetBox 4.6+) these helpers only accept `str` and raise `DjangoUnicodeDecodeError` on bytes that aren't valid UTF-8 — which random 32-byte session keys generally aren't.

Symptoms reported by anyone trying the plugin on NetBox 4.6.x:

```
POST /api/plugins/secrets/session-keys/
HTTP 500
{
  "error": "'utf-8' codec can't decode byte 0xdf in position 5: invalid continuation byte. You passed in b'r\\x00...\\xd4R\\xa1' (<class 'bytes'>)",
  "exception": "DjangoUnicodeDecodeError"
}
```

This blocks every workflow that needs a session key — i.e. anything that reads or writes a Secret value. Activation works because the master key never goes through `make_password`.

## Fix

Wrap the bytes through base64 before passing to Django's password hashers. Base64 is bijective on bytes, so the stored hash and any subsequent verification round-trip identically; no migration required for existing rows because they were never saved successfully on Django 5.x in the first place.

Touched 3 call sites in `netbox_secrets/models/keys.py`:

- `SessionKey.save()` — hash creation
- `SessionKey.get_master_key()` — hash verification on incoming session key
- `SessionKey.get_session_key()` — hash verification on derived session key

Behavioural change: zero on Django 4.x; works on Django 5.x.

## Verification

Manual end-to-end on NetBox `v4.6.0` + this fork:

```
POST /api/plugins/secrets/session-keys/    → 201, session_key returned
GET  /api/plugins/secrets/secrets/?...     → plaintext decrypted with X-Session-Key
POST /api/plugins/secrets/secrets/         → Secret created with plaintext, encrypted server-side
UserKey.activate() / get_master_key()      → works (already used base64-safe paths)
```

Full demo stack exercising this fix lives at `AlphaCompute/wyoming-demo` (NetBox 4.6 + Prometheus + Grafana for GPU fleet BMC monitoring) — passwords are stored as `netbox_secrets.Secret` and decrypted by a cron sync.

## Compatibility

Tested on:
- NetBox `v4.6.0-5.0.1` (netbox-docker 5.0.1, Django 5.x, Python 3.14)

Should not regress NetBox 4.5 — `make_password(str)` accepted both `str` and `bytes` historically, and base64-wrapping a value before hashing only changes the stored hash, which never escapes the row.

## Related

The plugin's `max_version` pin is still `4.5.99`, so even with this fix you must either bump it manually or sed-patch in the image. I'll open a separate PR to bump `max_version` once this one looks good — they're orthogonal changes, didn't want to mix them.

Happy to add unit tests if the project wants them; existing test suite does not appear to exercise SessionKey round-trip under Django 5.x.
